### PR TITLE
Add latest brew API and prefill option

### DIFF
--- a/src/app/api/brews/latest/route.ts
+++ b/src/app/api/brews/latest/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function GET() {
+  const brew = await prisma.brew.findFirst({
+    orderBy: { createdAt: "desc" },
+  });
+  if (!brew) {
+    return NextResponse.json({}, { status: 404 });
+  }
+  return NextResponse.json(brew);
+}

--- a/src/app/brews/new/page.tsx
+++ b/src/app/brews/new/page.tsx
@@ -109,6 +109,21 @@ export default function NewBrewPage() {
     setBrew({ ...brew, [e.target.name]: e.target.value });
   }
 
+  async function handleUseLastBrew() {
+    try {
+      const res = await fetch("/api/brews/latest");
+      if (!res.ok) {
+        setError("Failed to load last brew.");
+        return;
+      }
+      const { id, createdAt, ...brewData } = await res.json();
+      setBrew({ ...defaultBrew, ...brewData });
+      setError(null);
+    } catch (err: any) {
+      setError("Network error: " + err?.message);
+    }
+  }
+
   function validate(brewData: typeof defaultBrew) {
     for (const field of REQUIRED_FIELDS) {
       const value = brewData[field as keyof typeof brewData];
@@ -166,6 +181,11 @@ export default function NewBrewPage() {
 
   return (
     <main className="h-screen overflow-hidden">
+      <div className="p-4 flex justify-end">
+        <button type="button" className="btn-primary" onClick={handleUseLastBrew}>
+          Use Last Brew
+        </button>
+      </div>
       <form
         ref={formRef}
         onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary
- add new `/api/brews/latest` route to fetch last brew
- add a "Use Last Brew" button on new brew page to prefill form

## Testing
- `npm run lint` *(fails: no-explicit-any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683fbe104e8083219645af7270c9ea3a