### PR TITLE
Improve brew log UX

### DIFF
--- a/src/app/api/brews/route.ts
+++ b/src/app/api/brews/route.ts
@@ -23,7 +23,8 @@ export async function POST(req: NextRequest) {
   try {
     const brew = await prisma.brew.create({ data });
     return NextResponse.json(brew);
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/brews/suggestions/route.ts
+++ b/src/app/api/brews/suggestions/route.ts
@@ -1,5 +1,5 @@
 // File: src/app/api/brews/suggestions/route.ts
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { NextResponse } from "next/server";
 
 const prisma = new PrismaClient();
@@ -17,7 +17,7 @@ export async function GET() {
   for (const field of fields) {
     const values = await prisma.brew.findMany({
       select: { [field]: true },
-      distinct: [field as any],
+      distinct: [field as Prisma.BrewScalarFieldEnum],
       take: 20,
       orderBy: { date: "desc" },
     }) as Array<Record<string, unknown>>;

--- a/src/app/brews/new/page.tsx
+++ b/src/app/brews/new/page.tsx
@@ -148,8 +148,9 @@ export default function NewBrewPage() {
         return;
       }
       router.push("/brews");
-    } catch (err: any) {
-      setError("Network error: " + err?.message);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError("Network error: " + message);
       setSaving(false);
     }
   }

--- a/src/app/brews/page.tsx
+++ b/src/app/brews/page.tsx
@@ -37,6 +37,7 @@ type Brew = {
 
 export default function BrewsPage() {
   const [brews, setBrews] = useState<Brew[]>([]);
+  const [openIds, setOpenIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     fetch("/api/brews")
@@ -44,8 +45,7 @@ export default function BrewsPage() {
       .then(setBrews);
   }, []);
 
-  // List all fields to display as columns
-  const columns: { key: keyof Brew; label: string }[] = [
+  const detailColumns: { key: keyof Brew; label: string }[] = [
     { key: "date", label: "Date" },
     { key: "coffee", label: "Coffee" },
     { key: "roaster", label: "Roaster" },
@@ -77,8 +77,20 @@ export default function BrewsPage() {
     { key: "createdAt", label: "Created" },
   ];
 
+  function toggle(id: number) {
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
   return (
-    <main className="p-8 max-w-full mx-auto">
+    <main className="p-8 max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Brew Log</h1>
         <Link href="/brews/new">
@@ -86,31 +98,40 @@ export default function BrewsPage() {
         </Link>
       </div>
       {brews.length === 0 ? (
-        <div className="text-gray-500">No brews yet. Click "Add Brew" to get started!</div>
+        <div className="text-gray-500">No brews yet. Click &quot;Add Brew&quot; to get started!</div>
       ) : (
-        <div className="overflow-auto border rounded-xl">
-          <table className="min-w-[1500px] border-collapse text-xs">
-            <thead>
-              <tr>
-                {columns.map(col => (
-                  <th key={col.key as string} className="p-2 border-b font-bold text-left whitespace-nowrap bg-gray-50 sticky top-0 z-10">
-                    {col.label}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {brews.map((brew) => (
-                <tr key={brew.id} className="even:bg-gray-50">
-                  {columns.map(col => (
-                    <td key={col.key as string} className="p-2 border-b whitespace-nowrap max-w-[220px] overflow-x-auto">
-                      {(brew[col.key] ?? "").toString()}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="space-y-4">
+          {brews.map((brew) => (
+            <div key={brew.id} className="border rounded-lg">
+              <button
+                type="button"
+                onClick={() => toggle(brew.id)}
+                className="w-full flex justify-between items-center p-4 text-left"
+              >
+                <div>
+                  <div className="font-semibold">
+                    {brew.date} - {brew.coffee}
+                  </div>
+                  <div className="text-sm text-gray-600">{brew.roaster}</div>
+                </div>
+                <div className="text-sm text-gray-700">
+                  {brew.dose}g &bull; {brew.brewTime} &bull; {brew.score}
+                </div>
+              </button>
+              {openIds.has(brew.id) && (
+                <div className="p-4 border-t text-sm">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    {detailColumns.map((col) => (
+                      <div key={col.key as string} className="flex">
+                        <div className="font-semibold w-32 mr-2">{col.label}:</div>
+                        <div>{(brew[col.key] ?? "").toString()}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       )}
     </main>


### PR DESCRIPTION
## Summary
- show brew list as expandable cards instead of huge table
- allow toggling brew details
- remove bun.lock
- fix lint issues coming from `any` casts

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fbc04bc148321bc3a309900edf0c6