### PR TITLE
Implement brew draft persistence

### DIFF
--- a/src/app/api/brews/route.ts
+++ b/src/app/api/brews/route.ts
@@ -23,7 +23,8 @@ export async function POST(req: NextRequest) {
   try {
     const brew = await prisma.brew.create({ data });
     return NextResponse.json(brew);
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/brews/suggestions/route.ts
+++ b/src/app/api/brews/suggestions/route.ts
@@ -17,6 +17,7 @@ export async function GET() {
   for (const field of fields) {
     const values = await prisma.brew.findMany({
       select: { [field]: true },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       distinct: [field as any],
       take: 20,
       orderBy: { date: "desc" },

--- a/src/app/brews/new/page.tsx
+++ b/src/app/brews/new/page.tsx
@@ -94,6 +94,24 @@ export default function NewBrewPage() {
   const [suggestions, setSuggestions] = useState<Record<string, string[]>>({});
   const router = useRouter();
   const formRef = useRef<HTMLFormElement>(null);
+  const DRAFT_KEY = "brewDraft";
+
+  // Load saved draft on first render
+  useEffect(() => {
+    const saved = localStorage.getItem(DRAFT_KEY);
+    if (saved) {
+      try {
+        setBrew({ ...defaultBrew, ...JSON.parse(saved) });
+      } catch {
+        // ignore invalid draft
+      }
+    }
+  }, []);
+
+  // Save draft to localStorage whenever brew changes
+  useEffect(() => {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(brew));
+  }, [brew]);
 
   useEffect(() => {
     async function fetchSuggestions() {
@@ -147,11 +165,18 @@ export default function NewBrewPage() {
         setSaving(false);
         return;
       }
+      localStorage.removeItem(DRAFT_KEY);
       router.push("/brews");
-    } catch (err: any) {
-      setError("Network error: " + err?.message);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "";
+      setError("Network error: " + message);
       setSaving(false);
     }
+  }
+
+  function discardDraft() {
+    localStorage.removeItem(DRAFT_KEY);
+    setBrew(defaultBrew);
   }
 
   // Clear error when user navigates to a new section
@@ -448,6 +473,13 @@ export default function NewBrewPage() {
               {saving ? "Saving..." : "Save Brew"}
             </button>
             <Link href="/brews" className="btn-primary bg-gray-200 text-gray-900 hover:bg-gray-300">Cancel</Link>
+            <button
+              type="button"
+              onClick={discardDraft}
+              className="bg-red-500 text-white font-semibold py-2 px-4 rounded hover:bg-red-600"
+            >
+              Discard Draft
+            </button>
           </div>
         </section>
       </form>

--- a/src/app/brews/page.tsx
+++ b/src/app/brews/page.tsx
@@ -86,7 +86,7 @@ export default function BrewsPage() {
         </Link>
       </div>
       {brews.length === 0 ? (
-        <div className="text-gray-500">No brews yet. Click "Add Brew" to get started!</div>
+        <div className="text-gray-500">No brews yet. Click &quot;Add Brew&quot; to get started!</div>
       ) : (
         <div className="overflow-auto border rounded-xl">
           <table className="min-w-[1500px] border-collapse text-xs">


### PR DESCRIPTION
## Summary
- save brew form state to `localStorage`
- load draft from `localStorage` on page load
- add `Discard Draft` option to clear stored data
- fix ESLint issues in API routes and brews page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683fbe100228832184379b571efd599c